### PR TITLE
ci(lint): unfreeze ansible-lint version

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -26,8 +26,7 @@ jobs:
 
       - name: Install test dependencies.
         run: |
-          # FIXME: can not use ansible-lint==5.0.2 due to meta/main.yml
-          pip3 install ansible yamllint ansible-lint==5.0.1
+          pip3 install ansible yamllint ansible-lint
 
       - name: Lint code.
         run: |


### PR DESCRIPTION
Fixes broken builds (since https://github.com/particuleio/symplegma-flannel/actions/runs/870576901 )